### PR TITLE
Avg temp

### DIFF
--- a/ad7291.py
+++ b/ad7291.py
@@ -187,3 +187,13 @@ class AD7291:
             return (4096 - temperature)/4
         else:
             return temperature/4
+
+    @property
+    def read_avg_temperature(self):
+        """
+        Reads from the temperature average register. This register updates
+        after every temperature conversion and gets the average temperature
+        of the ADC since boot.
+        """
+
+        pass

--- a/ad7291.py
+++ b/ad7291.py
@@ -192,8 +192,10 @@ class AD7291:
     def read_avg_temperature(self):
         """
         Reads from the temperature average register. This register updates
-        after every temperature conversion and gets the average temperature
-        of the ADC since boot.
+        after every temperature conversion and gets a moving average of the ADC
+
+        The sensor uses the equation:
+            AVG = 0.875 * (Previous Average Result) + 0.125 * (Current Result)
         """
 
         if not self.settings >> 7:


### PR DESCRIPTION
Creating an average temperature property. This reads from the T sense average result register. Gives a moving average of the temperature of the ADC to account for fluctuation in the actual reading. Is likely a better way to keep track of the temperature of the ADC.